### PR TITLE
Add DoChannel method

### DIFF
--- a/client.go
+++ b/client.go
@@ -122,6 +122,11 @@ func (c *Client) DoAsync(req *Request) <-chan *Response {
 func (c *Client) DoBatch(workers int, reqs ...*Request) <-chan *Response {
 	// TODO: enable cancelling of batch jobs
 
+	// default one worker per request
+	if workers == 0 {
+		workers = len(reqs)
+	}
+
 	// start work queue
 	producer := make(chan *Request, 0)
 	go func() {
@@ -131,11 +136,6 @@ func (c *Client) DoBatch(workers int, reqs ...*Request) <-chan *Response {
 		}
 		close(producer)
 	}()
-
-	// default one worker per request
-	if workers == 0 {
-		workers = len(reqs)
-	}
 
 	return c.DoChannel(workers, producer)
 }
@@ -156,13 +156,13 @@ func (c *Client) DoBatch(workers int, reqs ...*Request) <-chan *Response {
 func (c *Client) DoChannel(workers int, reqs <-chan *Request) <-chan *Response {
 	// TODO: enable cancelling of batch jobs
 
-	responses := make(chan *Response, workers)
-	wg := sync.WaitGroup{}
-
 	// default one worker
 	if workers == 0 {
 		workers = 1
 	}
+
+	responses := make(chan *Response, workers)
+	wg := sync.WaitGroup{}
 
 	// start workers
 	for i := 0; i < workers; i++ {

--- a/grab.go
+++ b/grab.go
@@ -100,7 +100,7 @@ func GetAsync(dst, src string) (<-chan *Response, error) {
 // associated Response.Error field as soon as the Response.IsComplete method
 // returns true.
 //
-// GetBatch is a wrapper for DefaultClient.GetBatch.
+// GetBatch is a wrapper for DefaultClient.DoBatch.
 func GetBatch(workers int, dst string, sources ...string) (<-chan *Response, error) {
 	// default to current working directory
 	if dst == "" {


### PR DESCRIPTION
Fix #12.

I simply made a copy/paste of `DoBatch`. Now my `DoBatch` looks like this:

```go
func (c *Client) DoBatch(workers int, reqs ...*Request) <-chan *Response {
	// TODO: enable cancelling of batch jobs

	// start work queue
	producer := make(chan *Request, 0)
	go func() {
		// feed queue
		for i := 0; i < len(reqs); i++ {
			producer <- reqs[i]
		}
		close(producer)
	}()

	// default one worker per request
	if workers == 0 {
		workers = len(reqs)
	}

	return c.DoChannel(workers, producer)
}
```

It is the callers responsibility to close the `reqs` channel.