### PR TITLE
Check the Last-Modified header of the remote file

### DIFF
--- a/client.go
+++ b/client.go
@@ -187,6 +187,13 @@ func (c *Client) doHTTPRequest(hreq *http.Request, resp *Response) (bool, error)
 		hreq.Header.Set("User-Agent", c.UserAgent)
 	}
 
+	// TODO: set If-Modified-Since header
+	// https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25
+	// if resp.fi != nil {
+	// 	since := resp.fi.ModTime().Format(http.TimeFormat)
+	// 	hreq.Header.Set("If-Modified-Since", since)
+	// }
+
 	hresp, err := c.HTTPClient.Do(hreq)
 	if err != nil {
 		return false, err

--- a/client_test.go
+++ b/client_test.go
@@ -427,3 +427,44 @@ func TestRemoteTime(t *testing.T) {
 		t.Errorf("expected %v, got %v", time.Unix(lastmod, 0), fi.ModTime())
 	}
 }
+
+// TestTimeModified
+func TestLastModified(t *testing.T) {
+	filename := "./.testLastModified"
+	defer os.Remove(filename)
+
+	oldURL := fmt.Sprintf("%s?lastmod=%d", ts.URL, time.Now().Add(-24*time.Hour).Unix())
+	newURL := fmt.Sprintf("%s?lastmod=%d", ts.URL, time.Now().Unix())
+
+	// download initial file
+	if _, err := Get(filename, oldURL); err != nil {
+		panic(err)
+	}
+
+	// skip unmodifed remote file
+	resp, err := Get(filename, oldURL)
+	if err != nil {
+		panic(err)
+	}
+	if !resp.DidResume || resp.bytesResumed < 1 {
+		t.Errorf("expected client to skip unmodified file")
+	}
+
+	// download modified remote file
+	resp, err = Get(filename, newURL)
+	if err != nil {
+		panic(err)
+	}
+	if resp.DidResume || resp.bytesResumed != 0 {
+		t.Errorf("expected client to download modified file")
+	}
+
+	// skip unmodifed remote file
+	resp, err = Get(filename, oldURL)
+	if err != nil {
+		panic(err)
+	}
+	if !resp.DidResume || resp.bytesResumed < 1 {
+		t.Errorf("expected client to skip unmodified file")
+	}
+}

--- a/grab_test.go
+++ b/grab_test.go
@@ -69,7 +69,7 @@ var ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http
 			panic(err)
 		}
 		lastmodt := time.Unix(lastmodi, 0).UTC()
-		lastmod := lastmodt.Format("Mon, 02 Jan 2006 15:04:05") + " GMT"
+		lastmod := lastmodt.Format(http.TimeFormat)
 		w.Header().Set("Last-Modified", lastmod)
 	}
 

--- a/request.go
+++ b/request.go
@@ -45,9 +45,10 @@ type Request struct {
 	// exist.
 	NoCreateDirectories bool
 
-	// IgnoreRemoteTime specifies that grab should not attempt to set the
-	// timestamp of the local file to match the remote file.
-	IgnoreRemoteTime bool
+	// NoSetLocalModTime specifies that grab should not attempt to set the
+	// timestamp of the local file to match the remote file. The operating system
+	// will instead set the timestamp to the current system time.
+	NoSetLocalModTime bool
 
 	// Size specifies the expected size of the file transfer if known. If the
 	// server response size does not match, the transfer is cancelled and

--- a/util.go
+++ b/util.go
@@ -15,7 +15,7 @@ func isCanceled(ctx context.Context) error {
 	}
 }
 
-// copyBuffer behaves similarly to io.CopyBuffer except that is checks for
+// copyBuffer behaves similarly to io.CopyBuffer except that it checks for
 // cancelation of the given context.Context.
 func copyBuffer(ctx context.Context, dst io.Writer, src io.Reader, buf []byte) (written int64, err error) {
 	if buf == nil {


### PR DESCRIPTION
This PR aims to achieve the following outcomes:
* grab sets `If-Modified-Since` for completed downloads and checks for a `304` response
* grab compares `Last-Modified` headers with local timestamps when deciding to resume or overwrite incomplete downloads
* resumed downloads are never corrupted by remote file changes