### PR TITLE
Synchronized access to Response.transfer and Response.bytesResumed

### DIFF
--- a/client.go
+++ b/client.go
@@ -431,10 +431,11 @@ func (c *Client) copyFile(resp *Response) stateFunc {
 	b := make([]byte, resp.bufferSize)
 	go resp.watchBps()
 
+	transfer := newTransfer(resp.Request.Context(), resp.writer, resp.HTTPResponse.Body, b)
 	resp.transferMu.Lock()
-	defer resp.transferMu.Unlock()
-	resp.transfer = newTransfer(resp.Request.Context(), resp.writer, resp.HTTPResponse.Body, b)
-	if _, resp.err = resp.transfer.copy(); resp.err != nil {
+	resp.transfer = transfer
+	resp.transferMu.Unlock()
+	if _, resp.err = transfer.copy(); resp.err != nil {
 		return c.closeResponse
 	}
 

--- a/client.go
+++ b/client.go
@@ -429,6 +429,9 @@ func (c *Client) copyFile(resp *Response) stateFunc {
 	}
 	b := make([]byte, resp.bufferSize)
 	go resp.watchBps()
+
+	resp.transferMu.Lock()
+	defer resp.transferMu.Unlock()
 	resp.transfer = newTransfer(resp.Request.Context(), resp.writer, resp.HTTPResponse.Body, b)
 	if _, resp.err = resp.transfer.copy(); resp.err != nil {
 		return c.closeResponse

--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -229,7 +230,7 @@ func (c *Client) validateLocal(resp *Response) stateFunc {
 
 	if size == resp.fi.Size() {
 		resp.DidResume = true
-		resp.bytesResumed = resp.fi.Size()
+		atomic.StoreInt64(&resp.bytesResumed, resp.fi.Size())
 		return c.checksumFile
 	}
 
@@ -246,7 +247,7 @@ func (c *Client) validateLocal(resp *Response) stateFunc {
 	if resp.CanResume {
 		resp.Request.HTTPRequest.Header.Set("Range", fmt.Sprintf("bytes=%d-", resp.fi.Size()))
 		resp.DidResume = true
-		resp.bytesResumed = resp.fi.Size()
+		atomic.StoreInt64(&resp.bytesResumed, resp.fi.Size())
 		resp.writeFlags = os.O_APPEND | os.O_WRONLY
 		return c.getRequest
 	}
@@ -347,7 +348,7 @@ func (c *Client) readResponse(resp *Response) stateFunc {
 	}
 
 	// check expected size
-	resp.Size = resp.bytesResumed + resp.HTTPResponse.ContentLength
+	resp.Size = atomic.LoadInt64(&resp.bytesResumed) + resp.HTTPResponse.ContentLength
 	if resp.HTTPResponse.ContentLength > 0 && resp.Request.Size > 0 {
 		if resp.Request.Size != resp.Size {
 			resp.err = ErrBadLength
@@ -398,7 +399,7 @@ func (c *Client) openWriter(resp *Response) stateFunc {
 
 	// seek to start or end
 	whence := os.SEEK_SET
-	if resp.bytesResumed > 0 {
+	if atomic.LoadInt64(&resp.bytesResumed) > 0 {
 		whence = os.SEEK_END
 	}
 	_, resp.err = f.Seek(0, whence)

--- a/response.go
+++ b/response.go
@@ -142,9 +142,10 @@ func (c *Response) BytesComplete() int64 {
 // download is returned.
 func (c *Response) BytesPerSecond() float64 {
 	c.transferMu.Lock()
-	defer c.transferMu.Unlock()
+	transfer := c.transfer
+	c.transferMu.Unlock()
 	if c.IsComplete() {
-		return float64(c.transfer.N()) / c.Duration().Seconds()
+		return float64(transfer.N()) / c.Duration().Seconds()
 	}
 	c.bytesPerSecondMu.Lock()
 	defer c.bytesPerSecondMu.Unlock()
@@ -206,8 +207,9 @@ func (c *Response) watchBps() {
 			then = now
 
 			c.transferMu.Lock()
-			defer c.transferMu.Unlock()
-			cur := c.transfer.N()
+			transfer := c.transfer
+			c.transferMu.Unlock()
+			cur := transfer.N()
 			bs := cur - prev
 			prev = cur
 

--- a/response.go
+++ b/response.go
@@ -79,7 +79,8 @@ type Response struct {
 
 	// transfer is responsible for copying data from the remote server to a local
 	// file, tracking progress and allowing for cancelation.
-	transfer *transfer
+	transfer   *transfer
+	transferMu sync.Mutex
 
 	// bytesPerSecond specifies the number of bytes that have been transferred in
 	// the last 1-second window.
@@ -130,6 +131,8 @@ func (c *Response) Err() error {
 // the destination, including any bytes that were resumed from a previous
 // download.
 func (c *Response) BytesComplete() int64 {
+	c.transferMu.Lock()
+	defer c.transferMu.Unlock()
 	return c.bytesResumed + c.transfer.N()
 }
 
@@ -137,6 +140,8 @@ func (c *Response) BytesComplete() int64 {
 // the download is already complete, the average bytes/sec for the life of the
 // download is returned.
 func (c *Response) BytesPerSecond() float64 {
+	c.transferMu.Lock()
+	defer c.transferMu.Unlock()
 	if c.IsComplete() {
 		return float64(c.transfer.N()) / c.Duration().Seconds()
 	}
@@ -199,6 +204,8 @@ func (c *Response) watchBps() {
 			d := now.Sub(then)
 			then = now
 
+			c.transferMu.Lock()
+			defer c.transferMu.Unlock()
 			cur := c.transfer.N()
 			bs := cur - prev
 			prev = cur

--- a/response.go
+++ b/response.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -133,7 +134,7 @@ func (c *Response) Err() error {
 func (c *Response) BytesComplete() int64 {
 	c.transferMu.Lock()
 	defer c.transferMu.Unlock()
-	return c.bytesResumed + c.transfer.N()
+	return atomic.LoadInt64(&c.bytesResumed) + c.transfer.N()
 }
 
 // BytesPerSecond returns the number of bytes transferred in the last second. If


### PR DESCRIPTION
I've been experiencing "race condition detected" errors during tests, I'm displaying a progress bar during download (using another goroutine), that's why those fields needs to be protected for concurrent access.
