### PR TITLE
fix guessing filename from url if content-disposition header is missing

### DIFF
--- a/util_test.go
+++ b/util_test.go
@@ -34,6 +34,35 @@ func TestURLFilenames(t *testing.T) {
 		}
 	})
 
+	t.Run("Valid with Invalid Content-Disposition header", func(t *testing.T) {
+		expect := "filename"
+		testCases := []string{
+			"http://test.com/filename",
+			"http://test.com/path/filename",
+			"http://test.com/deep/path/filename",
+			"http://test.com/filename?with=args",
+			"http://test.com/filename#with-fragment",
+		}
+
+		for _, tc := range testCases {
+			req, _ := http.NewRequest("GET", tc, nil)
+			resp := &http.Response{
+				Request: req,
+				Header:  http.Header{},
+			}
+			resp.Header.Set("Content-Disposition", "attachment")
+			actual, err := guessFilename(resp)
+			if err != nil {
+				t.Errorf("%v", err)
+			}
+
+			if actual != expect {
+				t.Errorf("expected '%v', got '%v'", expect, actual)
+			}
+		}
+
+	})
+
 	t.Run("Invalid", func(t *testing.T) {
 		testCases := []string{
 			"http://test.com",
@@ -59,7 +88,7 @@ func TestURLFilenames(t *testing.T) {
 }
 
 func TestHeaderFilenames(t *testing.T) {
-	u, _ := url.ParseRequestURI("http://test.com/badfilename")
+	u, _ := url.ParseRequestURI("http://test.com/myfilename")
 	resp := &http.Response{
 		Request: &http.Request{
 			URL: u,
@@ -95,7 +124,8 @@ func TestHeaderFilenames(t *testing.T) {
 		}
 	})
 
-	t.Run("Invalid", func(t *testing.T) {
+	t.Run("Invalid header filenames, but valid filename from url", func(t *testing.T) {
+		expect := "myfilename"
 		testCases := []string{
 			"",
 			"/",
@@ -115,8 +145,13 @@ func TestHeaderFilenames(t *testing.T) {
 
 		for _, tc := range testCases {
 			setFilename(resp, tc)
-			if actual, err := guessFilename(resp); err != ErrNoFilename {
-				t.Errorf("expected: %v (%v), got: %v (%v)", ErrNoFilename, tc, err, actual)
+			actual, err := guessFilename(resp)
+			if err != nil {
+				t.Errorf("error (%v): %v", tc, err)
+			}
+
+			if actual != expect {
+				t.Errorf("expected '%v' (%v), got '%v'", expect, tc, actual)
 			}
 		}
 	})


### PR DESCRIPTION
related to https://github.com/cavaliercoder/grab/issues/47