### PR TITLE
[Feature] Add Socks5 Proxy support

### DIFF
--- a/client.go
+++ b/client.go
@@ -72,9 +72,9 @@ func NewClientWithProxy(proxy *socks.Proxy) *Client {
 // functions.
 var DefaultClient = NewClient()
 
-// SetDefaultClient allows you to setup the default client with a socks5
-// proxy.
-func SetDefaultClient(proxy *socks.Proxy) {
+// SetDefaultClientWithProxy allows you to setup the default client with
+// a socks5 proxy.
+func SetDefaultClientWithProxy(proxy *socks.Proxy) {
 	DefaultClient = NewClientWithProxy(proxy)
 }
 


### PR DESCRIPTION
Added `NewClientWithProxy` which allows using Socks5 proxies from `github.com/btcsuite/go-socks/socks`

Also added `SetDefaultClientWithProxy` so that convenience functions can benefit from this.