### PR TITLE
Check for missing filename directive in Content-disposition

### DIFF
--- a/util.go
+++ b/util.go
@@ -51,7 +51,9 @@ func guessFilename(resp *http.Response) (string, error) {
 	filename := resp.Request.URL.Path
 	if cd := resp.Header.Get("Content-Disposition"); cd != "" {
 		if _, params, err := mime.ParseMediaType(cd); err == nil {
-			filename = params["filename"]
+			if val, ok := params["filename"]; ok {
+				filename = val
+			} // else filename directive is missing.. fallback to URL.Path
 		}
 	}
 

--- a/util_test.go
+++ b/util_test.go
@@ -122,3 +122,37 @@ func TestHeaderFilenames(t *testing.T) {
 		}
 	})
 }
+
+func TestHeaderWithMissingDirective(t *testing.T) {
+	u, _ := url.ParseRequestURI("http://test.com/filename")
+	resp := &http.Response{
+		Request: &http.Request{
+			URL: u,
+		},
+		Header: http.Header{},
+	}
+
+	setHeader := func(resp *http.Response, value string) {
+		resp.Header.Set("Content-Disposition", value)
+	}
+
+	t.Run("Valid", func(t *testing.T) {
+		expect := "filename"
+		testCases := []string{
+			"inline",
+			"attachment",
+		}
+
+		for _, tc := range testCases {
+			setHeader(resp, tc)
+			actual, err := guessFilename(resp)
+			if err != nil {
+				t.Errorf("error (%v): %v", tc, err)
+			}
+
+			if actual != expect {
+				t.Errorf("expected '%v' (%v), got '%v'", expect, tc, actual)
+			}
+		}
+	})
+}


### PR DESCRIPTION
This PR adds an additional check in `guessFilename(resp *http.Response)` function to make sure that the we only read the `filename` from the `Content-disposition` header when the `filename` directive is supplied as it's completely legal and valid <sup>[[source]](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition)</sup> for the server to just return `inline` or `attachment` directives without supplying the `filename`

If we can't read the name from the header we simply fallback to `URL.Path` for `filename` value.

This PR fixes #64 