### PR TITLE
Cancel running request

### DIFF
--- a/client.go
+++ b/client.go
@@ -77,6 +77,7 @@ var DefaultClient = NewClient()
 func (c *Client) Do(req *Request) *Response {
 	// cancel will be called on all code-paths via closeResponse
 	ctx, cancel := context.WithCancel(req.Context())
+	req = req.WithContext(ctx)
 	resp := &Response{
 		Request:    req,
 		Start:      time.Now(),


### PR DESCRIPTION
A running request is currently not cancelled when the `Response.Cancel` is called.

This PR adds this feature.