### PR TITLE
Added HTTPClient Interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,13 +13,18 @@ import (
 	"time"
 )
 
+// HTTPClient provides an interface allowing us to perform HTTP requests.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // A Client is a file download client.
 //
 // Clients are safe for concurrent use by multiple goroutines.
 type Client struct {
 	// HTTPClient specifies the http.Client which will be used for communicating
 	// with the remote server during the file transfer.
-	HTTPClient *http.Client
+	HTTPClient HTTPClient
 
 	// UserAgent specifies the User-Agent string which will be set in the
 	// headers of all requests made by this client.


### PR DESCRIPTION
Just a quick PR: I changed the requirement of `*http.Client` to an interface type of `HTTPClient`.

This improves testability, by allowing test case/packages to implement their own `Do` method, whether that's faking/mocking a response from HTTP or intercepting a request before it's sent out.