### PR TITLE
Use more-permissive file masks

### DIFF
--- a/client.go
+++ b/client.go
@@ -430,7 +430,7 @@ func (c *Client) openWriter(resp *Response) stateFunc {
 		}
 
 		// open file
-		f, err := os.OpenFile(resp.Filename, flag, 0644)
+		f, err := os.OpenFile(resp.Filename, flag, 0666)
 		if err != nil {
 			resp.err = err
 			return c.closeResponse

--- a/util.go
+++ b/util.go
@@ -34,7 +34,7 @@ func mkdirp(path string) error {
 		if !os.IsNotExist(err) {
 			return fmt.Errorf("error checking destination directory: %v", err)
 		}
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0777); err != nil {
 			return fmt.Errorf("error creating destination directory: %v", err)
 		}
 	} else if !fi.IsDir() {


### PR DESCRIPTION
Per normal Go and OS behavior (and documentation, see os.File#Create,
and os#Mkdir), it should be safe to use more permissive modes because
the user's umask will be applied.

The upshot is that the user gets more control and typical expected
behavior without any added configuration.