### PR TITLE
Fix problem with Range bytes and multiple hosts via redirect

### DIFF
--- a/client.go
+++ b/client.go
@@ -352,6 +352,14 @@ func (c *Client) headRequest(resp *Response) stateFunc {
 		return c.getRequest
 	}
 
+	// In case of redirects during HEAD, record the final URL and use it
+	// instead of the original URL when sending future requests.
+	// This way we avoid sending potentially unsupported requests to
+	// the original URL, e.g. "Range", since it was the final URL
+	// that advertised its support.
+	resp.Request.HTTPRequest.URL = resp.HTTPResponse.Request.URL
+	resp.Request.HTTPRequest.Host = resp.HTTPResponse.Request.Host
+
 	return c.readResponse
 }
 


### PR DESCRIPTION
First of all thank you so much for this amazing library!

I'm attempting to download files from a host that uses a CDN. The host only acts as a resolver, so every response will be a redirect to the appropriate CDN resource. Now, imagine a file is only partially downloaded, and grab is attempting to resume. It will send a HEAD request to the host, which will redirect to the CDN, and the CDN will say that it supports partial downloads (`Range`). Grab will then proceed to send a GET request with `Range` header to the host, which returns 404 because it does not support `Range` - it was the CDN that advertised support for it. The correct scenario here, in my opinion, is to remember the redirect destination during The HEAD operation, and use that for future requests. This is what this CR achieves, in 2 lines of code :)