### PR TITLE
readme: fix syntax error in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Loop:
 		case <-t.C:
 			fmt.Printf("  transferred %v / %v bytes (%.2f%%)\n",
 				resp.BytesComplete(),
-				resp.Size(),
+				resp.Size,
 				100*resp.Progress())
 
 		case <-resp.Done:


### PR DESCRIPTION
grab.Response.Size is a int64 value and not a function

I noticed this problem when testing the example in the readme.

Hopefully this could help others...

![image](https://user-images.githubusercontent.com/29968201/106839037-63fd2380-666b-11eb-99aa-d7fc61a95a1f.png)
