### PR TITLE
Fix head break connection

### DIFF
--- a/v3/client.go
+++ b/v3/client.go
@@ -345,7 +345,7 @@ func (c *Client) headRequest(resp *Response) stateFunc {
 
 	resp.HTTPResponse, resp.err = c.doHTTPRequest(hreq)
 	if resp.err != nil {
-		return c.closeResponse
+		return c.getRequest
 	}
 	resp.HTTPResponse.Body.Close()
 

--- a/v3/client_test.go
+++ b/v3/client_test.go
@@ -317,6 +317,17 @@ func TestAutoResume(t *testing.T) {
 			grabtest.HeaderBlacklist("Content-Length"),
 		)
 	})
+
+	t.Run("WithHeadRequestBreak", func(t *testing.T) {
+		grabtest.WithTestServer(t, func(url string) {
+			req := mustNewRequest(filename, url)
+			resp := DefaultClient.Do(req)
+			testComplete(t, resp)
+		},
+			grabtest.WithBreakHeadRequest(),
+		)
+	})
+
 	// TODO: test when existing file is corrupted
 }
 

--- a/v3/client_test.go
+++ b/v3/client_test.go
@@ -1,5 +1,6 @@
 package grab
 
+//nolint:gosec
 import (
 	"bytes"
 	"context"
@@ -10,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"hash"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -42,7 +42,7 @@ func TestFilenameResolution(t *testing.T) {
 		{"Failure", "", "", "", ""},
 	}
 
-	err := os.Mkdir(".test", 0777)
+	err := os.Mkdir(".test", 0o777)
 	if err != nil {
 		panic(err)
 	}
@@ -78,6 +78,8 @@ func TestFilenameResolution(t *testing.T) {
 
 // TestChecksums checks that checksum validation behaves as expected for valid
 // and corrupted downloads.
+//
+//nolint:gosec
 func TestChecksums(t *testing.T) {
 	tests := []struct {
 		size  int
@@ -205,7 +207,7 @@ func TestContentLength(t *testing.T) {
 func TestAutoResume(t *testing.T) {
 	segs := 8
 	size := 1048576
-	sum := grabtest.DefaultHandlerSHA256ChecksumBytes //grab/v3test.MustHexDecodeString("fbbab289f7f94b25736c58be46a994c441fd02552cc6022352e3d86d2fab7c83")
+	sum := grabtest.DefaultHandlerSHA256ChecksumBytes // grab/v3test.MustHexDecodeString("fbbab289f7f94b25736c58be46a994c441fd02552cc6022352e3d86d2fab7c83")
 	filename := ".testAutoResume"
 
 	defer os.Remove(filename)
@@ -393,22 +395,21 @@ func TestBatch(t *testing.T) {
 			// listen for responses
 		Loop:
 			for i := 0; i < len(reqs); {
-				select {
-				case resp := <-responses:
-					if resp == nil {
-						break Loop
-					}
-					testComplete(t, resp)
-					if err := resp.Err(); err != nil {
-						t.Errorf("%s: %v", resp.Filename, err)
-					}
-
-					// remove test file
-					if resp.IsComplete() {
-						os.Remove(resp.Filename) // ignore errors
-					}
-					i++
+				resp := <-responses
+				if resp == nil {
+					break Loop
 				}
+				testComplete(t, resp)
+				if err := resp.Err(); err != nil {
+					t.Errorf("%s: %v", resp.Filename, err)
+				}
+
+				// remove test file
+				if resp.IsComplete() {
+					os.Remove(resp.Filename) // ignore errors
+				}
+				i++
+
 			}
 		}
 	},
@@ -437,7 +438,7 @@ func TestCancelContext(t *testing.T) {
 		time.Sleep(time.Millisecond * 500)
 		cancel()
 		for resp := range respch {
-			defer os.Remove(resp.Filename)
+			defer os.Remove(resp.Filename) //nolint:staticcheck
 
 			// err should be context.Canceled or http.errRequestCanceled
 			if resp.Err() == nil || !strings.Contains(resp.Err().Error(), "canceled") {
@@ -527,7 +528,7 @@ func TestRemoteTime(t *testing.T) {
 	defer os.Remove(filename)
 
 	// random time between epoch and now
-	expect := time.Unix(rand.Int63n(time.Now().Unix()), 0)
+	expect := time.Unix(rand.Int63n(time.Now().Unix()), 0) //nolint:gosec
 	grabtest.WithTestServer(t, func(url string) {
 		resp := mustDo(mustNewRequest(filename, url))
 		fi, err := os.Stat(resp.Filename)
@@ -636,7 +637,7 @@ func TestBeforeCopyHook(t *testing.T) {
 	// Assert that an existing local file will not be truncated prior to the
 	// BeforeCopy hook has a chance to cancel the request
 	t.Run("NoTruncate", func(t *testing.T) {
-		tfile, err := ioutil.TempFile("", "grab_client_test.*.file")
+		tfile, err := os.CreateTemp("", "grab_client_test.*.file")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -819,7 +820,7 @@ func TestMissingContentLength(t *testing.T) {
 	grabtest.WithTestServer(t, func(url string) {
 		req := mustNewRequest(".testMissingContentLength", url)
 		req.SetChecksum(
-			md5.New(),
+			md5.New(), //nolint:gosec
 			grabtest.DefaultHandlerMD5ChecksumBytes,
 			false)
 		resp := DefaultClient.Do(req)
@@ -855,7 +856,7 @@ func TestNoStore(t *testing.T) {
 		grabtest.WithTestServer(t, func(url string) {
 			req := mustNewRequest(filename, url)
 			req.NoStore = true
-			req.SetChecksum(md5.New(), grabtest.DefaultHandlerMD5ChecksumBytes, true)
+			req.SetChecksum(md5.New(), grabtest.DefaultHandlerMD5ChecksumBytes, true) //nolint:gosec
 			resp := mustDo(req)
 
 			// ensure Response.Bytes is correct and can be reread
@@ -913,7 +914,7 @@ func TestNoStore(t *testing.T) {
 			req := mustNewRequest("", url)
 			req.NoStore = true
 			req.SetChecksum(
-				md5.New(),
+				md5.New(), //nolint:gosec
 				grabtest.MustHexDecodeString("deadbeefcafebabe"),
 				true)
 			resp := DefaultClient.Do(req)

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -1,3 +1,3 @@
 module github.com/cavaliergopher/grab/v3
 
-go 1.14
+go 1.19

--- a/v3/grab_test.go
+++ b/v3/grab_test.go
@@ -2,7 +2,6 @@ package grab
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -17,7 +16,7 @@ func TestMain(m *testing.M) {
 		if err != nil {
 			panic(err)
 		}
-		tmpDir, err := ioutil.TempDir("", "grab-")
+		tmpDir, err := os.MkdirTemp("", "grab-")
 		if err != nil {
 			panic(err)
 		}
@@ -25,7 +24,7 @@ func TestMain(m *testing.M) {
 			panic(err)
 		}
 		defer func() {
-			os.Chdir(cwd)
+			_ = os.Chdir(cwd)
 			if err := os.RemoveAll(tmpDir); err != nil {
 				panic(err)
 			}

--- a/v3/pkg/grabtest/assert.go
+++ b/v3/pkg/grabtest/assert.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 )
@@ -15,7 +14,6 @@ func AssertHTTPResponseStatusCode(t *testing.T, resp *http.Response, expect int)
 		t.Errorf("expected status code: %d, got: %d", expect, resp.StatusCode)
 		return
 	}
-	ok = true
 	return true
 }
 
@@ -48,7 +46,7 @@ func AssertHTTPResponseBodyLength(t *testing.T, resp *http.Response, n int64) (o
 			panic(err)
 		}
 	}()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic(err)
 	}
@@ -77,7 +75,7 @@ func MustHTTPDo(req *http.Request) *http.Response {
 
 func MustHTTPDoWithClose(req *http.Request) *http.Response {
 	resp := MustHTTPDo(req)
-	if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
 		panic(err)
 	}
 	if err := resp.Body.Close(); err != nil {

--- a/v3/pkg/grabtest/handler.go
+++ b/v3/pkg/grabtest/handler.go
@@ -155,7 +155,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// use buffered io to reduce overhead on the reader
 		bw := bufio.NewWriterSize(w, 4096)
 		for i := offset; !isRequestClosed(r) && i < h.contentLength; i++ {
-			bw.Write([]byte{byte(i)})
+			_, _ = bw.Write([]byte{byte(i)})
 			if h.rateLimiter != nil {
 				bw.Flush()
 				w.(http.Flusher).Flush() // force the server to send the data to the client

--- a/v3/pkg/grabtest/handler_option.go
+++ b/v3/pkg/grabtest/handler_option.go
@@ -90,3 +90,11 @@ func AttachmentFilename(filename string) HandlerOption {
 		return nil
 	}
 }
+
+func WithBreakHeadRequest() HandlerOption {
+	return func(h *handler) error {
+		h.withBreakHeadRequest = true
+		h.withBreakGetRequestCh = make(chan struct{})
+		return nil
+	}
+}

--- a/v3/pkg/grabtest/handler_test.go
+++ b/v3/pkg/grabtest/handler_test.go
@@ -2,7 +2,7 @@ package grabtest
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -84,7 +84,7 @@ func TestHandlerContentLength(t *testing.T) {
 
 			AssertHTTPResponseHeader(t, resp, "Content-Length", "%d", test.ExpectHeaderLen)
 
-			b, err := ioutil.ReadAll(resp.Body)
+			b, err := io.ReadAll(resp.Body)
 			if err != nil {
 				panic(err)
 			}

--- a/v3/pkg/grabui/console_client.go
+++ b/v3/pkg/grabui/console_client.go
@@ -155,7 +155,7 @@ func byteString(n int64) string {
 }
 
 func etaString(eta time.Time) string {
-	d := eta.Sub(time.Now())
+	d := time.Until(eta)
 	if d < time.Second {
 		return "<1s"
 	}

--- a/v3/response.go
+++ b/v3/response.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"sync/atomic"
@@ -169,7 +168,7 @@ func (c *Response) Duration() time.Duration {
 		return c.End.Sub(c.Start)
 	}
 
-	return time.Now().Sub(c.Start)
+	return time.Since(c.Start)
 }
 
 // ETA returns the estimated time at which the the download will complete, given
@@ -204,7 +203,7 @@ func (c *Response) Open() (io.ReadCloser, error) {
 
 func (c *Response) openUnsafe() (io.ReadCloser, error) {
 	if c.Request.NoStore {
-		return ioutil.NopCloser(bytes.NewReader(c.storeBuffer.Bytes())), nil
+		return io.NopCloser(bytes.NewReader(c.storeBuffer.Bytes())), nil
 	}
 	return os.Open(c.Filename)
 }
@@ -226,7 +225,7 @@ func (c *Response) Bytes() ([]byte, error) {
 		return nil, err
 	}
 	defer f.Close()
-	return ioutil.ReadAll(f)
+	return io.ReadAll(f)
 }
 
 func (c *Response) requestMethod() string {


### PR DESCRIPTION
## Problem
I tried to use grab and tested download from server https://speed.hetzner.de
When I retried download to partially saved file grab failed with `nil` response and error `Head EOF`

I've researched the source of the problem. Remote server breaks the connection on HEAD request, but works good at GET request. So, I think that in this case grab should not fail after HEAD and go further and try GET.

This PR fixes this.

## Solution

### Test

I've added test that emulate HEAD request breaking connection `WithHeadRequestBreak`. 

### Fix

In headRequest State Function in branch with response error grab now does not closing the response but go to GET request.

`client.Do(req)` returns only `nil` response along with error, so there is no need to close nil response.

## Other fixes

I've added one more commit to PR with linter fixes and update of the Go version.