### PR TITLE
Implement optional concurrent "Range" requests (refs #86)

### DIFF
--- a/v3/go.mod
+++ b/v3/go.mod
@@ -1,3 +1,5 @@
 module github.com/cavaliergopher/grab/v3
 
 go 1.14
+
+require golang.org/x/sync v0.3.0

--- a/v3/go.sum
+++ b/v3/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=

--- a/v3/pkg/grabtest/handler.go
+++ b/v3/pkg/grabtest/handler.go
@@ -35,10 +35,15 @@ type handler struct {
 
 func NewHandler(options ...HandlerOption) (http.Handler, error) {
 	h := &handler{
-		statusCodeFunc:  func(req *http.Request) int { return http.StatusOK },
 		methodWhitelist: []string{"GET", "HEAD"},
 		contentLength:   DefaultHandlerContentLength,
 		acceptRanges:    true,
+	}
+	h.statusCodeFunc = func(req *http.Request) int {
+		if h.acceptRanges && strings.HasPrefix(req.Header.Get("Range"), "bytes=") {
+			return http.StatusPartialContent
+		}
+		return http.StatusOK
 	}
 	for _, option := range options {
 		if err := option(h); err != nil {

--- a/v3/pkg/grabtest/handler.go
+++ b/v3/pkg/grabtest/handler.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -106,20 +108,55 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Last-Modified", lastMod.Format(http.TimeFormat))
 
 	// set content-length
-	offset := 0
+	var offset int64
+	length := int64(h.contentLength)
 	if h.acceptRanges {
 		if reqRange := r.Header.Get("Range"); reqRange != "" {
-			if _, err := fmt.Sscanf(reqRange, "bytes=%d-", &offset); err != nil {
+			const b = `bytes=`
+			var limit int64
+			start, end, ok := strings.Cut(reqRange[len(b):], "-")
+			if !ok {
 				httpError(w, http.StatusBadRequest)
 				return
 			}
-			if offset >= h.contentLength {
-				httpError(w, http.StatusRequestedRangeNotSatisfiable)
+			var err error
+			if start != "" {
+				offset, err = strconv.ParseInt(start, 10, 64)
+				if err != nil {
+					httpError(w, http.StatusBadRequest)
+					return
+				}
+				if offset > length {
+					offset = length
+				}
+			}
+			if end != "" {
+				limit, err = strconv.ParseInt(end, 10, 64)
+				if err != nil {
+					httpError(w, http.StatusBadRequest)
+					return
+				}
+			}
+
+			if start != "" && end == "" {
+				length = length - offset
+			} else if start == "" && end != "" {
+				// unsupported range format: -<end>
+				httpError(w, http.StatusBadRequest)
+			} else {
+				length = limit - offset
+			}
+
+			if length > int64(h.contentLength) {
+				code := http.StatusRequestedRangeNotSatisfiable
+				msg := fmt.Sprintf("%s: requested range length %d "+
+					"is greater than ContentLength %d", http.StatusText(code), length, h.contentLength)
+				http.Error(w, msg, code)
 				return
 			}
 		}
 	}
-	w.Header().Set("Content-Length", fmt.Sprintf("%d", h.contentLength-offset))
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", length))
 
 	// apply header blacklist
 	for _, key := range h.headerBlacklist {
@@ -133,7 +170,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method == "GET" {
 		// use buffered io to reduce overhead on the reader
 		bw := bufio.NewWriterSize(w, 4096)
-		for i := offset; !isRequestClosed(r) && i < h.contentLength; i++ {
+		for i := offset; !isRequestClosed(r) && i < int64(offset+length); i++ {
 			bw.Write([]byte{byte(i)})
 			if h.rateLimiter != nil {
 				bw.Flush()

--- a/v3/request.go
+++ b/v3/request.go
@@ -108,6 +108,12 @@ type Request struct {
 	// the concurrent range request chunks
 	RangeRequestMax int
 
+	// RangeRequestMax sets minimum size in bytes for the Content-Length of the
+	// remote file to be downloaded using a "Range" request. If the file size
+	// is less than RangeRequestMinSize, then the entire body will be downloaded
+	// using a normal request.
+	RangeRequestMinSize int64
+
 	// hash, checksum and deleteOnError - set via SetChecksum.
 	hash          hash.Hash
 	checksum      []byte

--- a/v3/request.go
+++ b/v3/request.go
@@ -99,6 +99,15 @@ type Request struct {
 	// the Response object.
 	AfterCopy Hook
 
+	// RangeRequestMax enables the use of "Range" requests, if supported by the
+	// server, to download multiple chunks. A value > 0 defines how many chunks
+	// to execute concurrently.
+	// If the server does not support "accept-range", then the original single
+	// request behaviour is used.
+	// Note that the BufferSize will be applied as a separate buffer for each of
+	// the concurrent range request chunks
+	RangeRequestMax int
+
 	// hash, checksum and deleteOnError - set via SetChecksum.
 	hash          hash.Hash
 	checksum      []byte

--- a/v3/response.go
+++ b/v3/response.go
@@ -82,7 +82,7 @@ type Response struct {
 	// enabled.
 	storeBuffer bytes.Buffer
 
-	// bytesCompleted specifies the number of bytes which were already
+	// bytesResumed specifies the number of bytes which were already
 	// transferred before this transfer began.
 	bytesResumed int64
 
@@ -259,4 +259,13 @@ func (c *Response) closeResponseBody() error {
 		return nil
 	}
 	return c.HTTPResponse.Body.Close()
+}
+
+func (c *Response) isRangeRequest() bool {
+	if c.Request.RangeRequestMax > 0 && c.acceptRanges {
+		if c.HTTPResponse.ContentLength >= c.Request.RangeRequestMinSize {
+			return true
+		}
+	}
+	return false
 }

--- a/v3/response.go
+++ b/v3/response.go
@@ -47,6 +47,10 @@ type Response struct {
 	// previous downloads, as the 'Accept-Ranges: bytes' header is set.
 	CanResume bool
 
+	// specifies that the remote server advertised that it supports partial
+	// requests, as the 'Accept-Ranges: bytes' header is set.
+	acceptRanges bool
+
 	// DidResume specifies that the file transfer resumed a previously incomplete
 	// transfer.
 	DidResume bool
@@ -84,7 +88,7 @@ type Response struct {
 
 	// transfer is responsible for copying data from the remote server to a local
 	// file, tracking progress and allowing for cancelation.
-	transfer *transfer
+	transfer transferer
 
 	// bufferSize specifies the size in bytes of the transfer buffer.
 	bufferSize int
@@ -242,8 +246,8 @@ func (c *Response) checksumUnsafe() ([]byte, error) {
 		return nil, err
 	}
 	defer f.Close()
-	t := newTransfer(c.Request.Context(), nil, c.Request.hash, f, nil)
-	if _, err = t.copy(); err != nil {
+	t := newTransfer(c.Request.Context(), nil, c.Request.hash, f, 0)
+	if _, err = t.Copy(); err != nil {
 		return nil, err
 	}
 	sum := c.Request.hash.Sum(nil)

--- a/v3/transfer.go
+++ b/v3/transfer.go
@@ -2,47 +2,76 @@ package grab
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
+	"net/http"
 	"sync/atomic"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/cavaliergopher/grab/v3/pkg/bps"
 )
 
-type transfer struct {
-	n     int64 // must be 64bit aligned on 386
-	ctx   context.Context
-	gauge bps.Gauge
-	lim   RateLimiter
-	w     io.Writer
-	r     io.Reader
-	b     []byte
+type transferer interface {
+	// Copy performs the bytes copy from the reader to the writer,
+	// reports the progress, and transfer rate.
+	// Returns bytes written and error, using same behaviour as io.Copy.Buffer
+	Copy() (written int64, err error)
+	// N returns the number of bytes transferred.
+	N() int64
+	// BPS returns the current bytes per second transfer rate using a simple moving average.
+	BPS() float64
 }
 
-func newTransfer(ctx context.Context, lim RateLimiter, dst io.Writer, src io.Reader, buf []byte) *transfer {
+func newGauge() bps.Gauge {
+	// five second moving average sampling every second
+	return bps.NewSMA(6)
+
+}
+
+type transfer struct {
+	n       int64 // must be 64bit aligned on 386
+	ctx     context.Context
+	gauge   bps.Gauge
+	lim     RateLimiter
+	w       io.Writer
+	r       io.Reader
+	bufSize int
+}
+
+func newTransfer(ctx context.Context, lim RateLimiter, dst io.Writer, src io.Reader, bufSize int) *transfer {
 	return &transfer{
-		ctx:   ctx,
-		gauge: bps.NewSMA(6), // five second moving average sampling every second
-		lim:   lim,
-		w:     dst,
-		r:     src,
-		b:     buf,
+		ctx:     ctx,
+		gauge:   newGauge(),
+		lim:     lim,
+		w:       dst,
+		r:       src,
+		bufSize: bufSize,
 	}
 }
 
-// copy behaves similarly to io.CopyBuffer except that it checks for cancelation
+// Copy behaves similarly to io.CopyBuffer except that it checks for cancelation
 // of the given context.Context, reports progress in a thread-safe manner and
 // tracks the transfer rate.
-func (c *transfer) copy() (written int64, err error) {
+func (c *transfer) Copy() (written int64, err error) {
+	if c == nil {
+		return 0, errors.New("nil *transfer instance")
+	}
+
 	// maintain a bps gauge in another goroutine
 	ctx, cancel := context.WithCancel(c.ctx)
 	defer cancel()
 	go bps.Watch(ctx, c.gauge, c.N, time.Second)
 
 	// start the transfer
-	if c.b == nil {
-		c.b = make([]byte, 32*1024)
+	bufSize := c.bufSize
+	if bufSize < 1 {
+		bufSize = 32 * 1024
 	}
+	buf := make([]byte, bufSize)
+
 	for {
 		select {
 		case <-c.ctx.Done():
@@ -51,9 +80,9 @@ func (c *transfer) copy() (written int64, err error) {
 		default:
 			// keep working
 		}
-		nr, er := c.r.Read(c.b)
+		nr, er := c.r.Read(buf)
 		if nr > 0 {
-			nw, ew := c.w.Write(c.b[0:nr])
+			nw, ew := c.w.Write(buf[0:nr])
 			if nw > 0 {
 				written += int64(nw)
 				atomic.StoreInt64(&c.n, written)
@@ -85,17 +114,167 @@ func (c *transfer) copy() (written int64, err error) {
 }
 
 // N returns the number of bytes transferred.
-func (c *transfer) N() (n int64) {
+func (c *transfer) N() int64 {
 	if c == nil {
 		return 0
 	}
-	n = atomic.LoadInt64(&c.n)
-	return
+	return atomic.LoadInt64(&c.n)
 }
 
 // BPS returns the current bytes per second transfer rate using a simple moving
 // average.
-func (c *transfer) BPS() (bps float64) {
+func (c *transfer) BPS() float64 {
+	if c == nil || c.gauge == nil {
+		return 0
+	}
+	return c.gauge.BPS()
+}
+
+type transferRanges struct {
+	n       int64 // must be 64bit aligned on 386
+	ctx     context.Context
+	client  HTTPClient
+	gauge   bps.Gauge
+	lim     RateLimiter
+	w       io.WriterAt
+	r       *http.Request
+	length  int64
+	workers int
+	bufSize int
+}
+
+func newTransferRanges(client HTTPClient, headResp *Response, dst io.WriterAt) *transferRanges {
+	return &transferRanges{
+		ctx:     headResp.Request.Context(),
+		client:  client,
+		gauge:   newGauge(),
+		lim:     headResp.Request.RateLimiter,
+		w:       dst,
+		r:       headResp.Request.HTTPRequest,
+		length:  headResp.HTTPResponse.ContentLength,
+		workers: headResp.Request.RangeRequestMax,
+		bufSize: headResp.bufferSize,
+	}
+}
+
+// Copy performs concurrent http Range requests to transfer chunks and write them at
+// offsets to the WriterAt instance.
+// Checks for cancelation of the given context.Context, reports progress in a
+// thread-safe manner and tracks the transfer rate.
+func (c *transferRanges) Copy() (written int64, err error) {
+	if c == nil {
+		return 0, errors.New("nil *transferRanges instance")
+	}
+
+	if c.length == 0 {
+		err = errors.New("cannot transfer ranges: ContentLength is 0")
+		return
+	}
+
+	if c.workers < 1 {
+		c.workers = 1
+	}
+
+	if c.bufSize < 1 {
+		c.bufSize = 32 * 1024
+	}
+
+	c.n = 0
+
+	// maintain a bps gauge in another goroutine
+	ctx, cancel := context.WithCancel(c.ctx)
+	defer cancel()
+	go bps.Watch(ctx, c.gauge, c.N, time.Second)
+
+	wg, ctx := errgroup.WithContext(ctx)
+
+	chunkSize := c.length / int64(c.workers)
+	var start, end int64
+	for i := 1; i <= c.workers; i++ {
+		if i == c.workers {
+			end = c.length
+		} else {
+			end = start + chunkSize
+		}
+		offset := start
+		limit := end
+		wg.Go(func() error {
+			return c.requestChunk(ctx, offset, limit)
+		})
+		start = end
+	}
+
+	err = wg.Wait()
+	return c.N(), err
+}
+
+func (c *transferRanges) requestChunk(ctx context.Context, offset, limit int64) error {
+	req := c.r.Clone(ctx)
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", offset, limit))
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusPartialContent {
+		return fmt.Errorf("server responded with %d status code, expected %d for range request",
+			resp.StatusCode, http.StatusPartialContent)
+	}
+
+	defer resp.Body.Close()
+
+	// start the transfer
+	buf := make([]byte, c.bufSize)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			// keep working
+		}
+		nr, er := resp.Body.Read(buf)
+		if nr > 0 {
+			nw, ew := c.w.WriteAt(buf[0:nr], offset)
+			if nw > 0 {
+				atomic.AddInt64(&c.n, int64(nw))
+			}
+			if ew != nil {
+				return ew
+			}
+			if nr != nw {
+				return io.ErrShortWrite
+			}
+			offset += int64(nw)
+			// wait for rate limiter
+			if c.lim != nil {
+				if er = c.lim.WaitN(ctx, nr); er != nil {
+					return er
+				}
+			}
+		}
+		if er != nil {
+			if er != io.EOF {
+				return er
+			}
+			break
+		}
+	}
+
+	return nil
+}
+
+// N returns the total number of bytes transferred across all concurrent chunks.
+func (c *transferRanges) N() int64 {
+	if c == nil {
+		return 0
+	}
+	return atomic.LoadInt64(&c.n)
+}
+
+// BPS returns the current bytes per second transfer rate using a simple moving
+// average, across all concurrent chunks.
+func (c *transferRanges) BPS() float64 {
 	if c == nil || c.gauge == nil {
 		return 0
 	}


### PR DESCRIPTION
This is an implementation of an optional feature to have a `Request` download the payload in multiple chunks, using a "Range" request, if supported by the server. 

## API updates

The `Request` struct gains a new field called `RangeRequestMax`, which when set to > 0 controls how many chunks to download in parallel using a "Range" request, instead of a single request reading the full body.

## Implementation details

### High level steps:

1. `RangeRequestMax` > 0
2. Ensure that a head request is always performed, so we can verify the support for "Range" and get the content length
3. Don't start the synchronous GET request in the state machine, as it will be executed in parallel later (HEAD request is the last request performed)
4. Transition to openWriter
5. Use an alternate `transfer` implementation, called `transferRanges`
6. async `copyFile` works the same as before

Given the way the state machine works, it seemed easier to launch the concurrent range requests during the copy phase, instead of in the synchronous `getRequest` state and have to monitor a list of requests.

A new `transferer` interface  has been introduced, to have a second implementation called `transferRanges`

### `transferRanges` implementation

This alternate implementation handles launching the concurrent range requests, doing the copy of the data, and tracking the metrics. 

It seemed easier to just pass the HEAD `Response` to the private constructor, as most of the needed details are present on that struct. 

`transferRanges.Copy()` will start a number of Range requests with an `offset-limit` in goroutines, per the value of `RangeRequestMax` passed in. Each goroutines writes directly to the open file writer using `WriteAt` (with underlying `pwrite()` syscall) to write chunks of data at offsets to the same file descriptor in parallel. Metrics are atomically updated to keep `N()` and `BPS()` working.

### Other details

I did also update the default setting in the `Client` when it comes to setting "TCP_NODELAY". In Go standard lib, this is set to `true` in the `net.TCPConn` to target rpc workloads. But it would make more sense, in theory, to disable Nagles Algorithm by default in a library specific to downloading files over HTTP. It can still be controlled by the user supplying a custom `HTTPClient`