### PR TITLE
Change default user agent to meet specification, fix #104 

### DIFF
--- a/v3/client.go
+++ b/v3/client.go
@@ -49,7 +49,7 @@ type Client struct {
 // NewClient returns a new file download Client, using default configuration.
 func NewClient() *Client {
 	return &Client{
-		UserAgent: "grab",
+		UserAgent: "grab/3"
 		HTTPClient: &http.Client{
 			Transport: &http.Transport{
 				Proxy: http.ProxyFromEnvironment,

--- a/v3/client.go
+++ b/v3/client.go
@@ -49,7 +49,7 @@ type Client struct {
 // NewClient returns a new file download Client, using default configuration.
 func NewClient() *Client {
 	return &Client{
-		UserAgent: "grab/3"
+		UserAgent: "grab/3",
 		HTTPClient: &http.Client{
 			Transport: &http.Transport{
 				Proxy: http.ProxyFromEnvironment,


### PR DESCRIPTION
The specification described [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) suggests that UserAgent must follow a particular format. It seems that GitHub has decided to strictly enforce the [requirement](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#user-agent-required).

The fix includes the version of grab (currently v3) in the default `UserAgent` string.